### PR TITLE
Don't wait for data in non-blocking curl() open()

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -209,7 +209,7 @@ static Rboolean rcurl_open(Rconnection con) {
 
  /* Wait for first data to arrive. Monitoring a change in status code does not
    suffice in case of http redirects */
-  while(req->has_more && !req->has_data) {
+  while(con->blocking && req->has_more && !req->has_data) {
 #ifdef HAS_MULTI_WAIT
     int numfds;
     massert(curl_multi_wait(req->manager, NULL, 0, 1000, &numfds));

--- a/src/curl.c
+++ b/src/curl.c
@@ -133,8 +133,11 @@ static size_t rcurl_read(void *target, size_t sz, size_t ni, Rconnection con) {
 #endif
     fetchdata(req);
     total_size += pop((char*)target + total_size, (req_size-total_size), req);
-    if(con->blocking == FALSE)
+    if(con->blocking == FALSE) {
+      CURL *handle = req->handle;
+      stop_for_status(handle);
       break;
+    }
   }
   con->incomplete = req->has_more || req->size;
   return total_size;

--- a/tests/testthat/test-nonblocking.R
+++ b/tests/testthat/test-nonblocking.R
@@ -5,13 +5,13 @@ test_that("Non blocking connections ", {
   con <- curl(httpbin("drip?duration=3&numbytes=50&code=200"), handle = h)
   expect_equal(handle_data(h)$status_code, 0L)
   open(con, "rb", blocking = FALSE)
-  expect_equal(handle_data(h)$status_code, 200L)
   n <- 0
   while(isIncomplete(con)){
     Sys.sleep(0.01)
     buf <- readBin(con, raw(), 5)
     n <- n + length(buf)
   }
+  expect_equal(handle_data(h)$status_code, 200L)
   expect_equal(n, 50L)
   rm(h)
   close(con)


### PR DESCRIPTION
This is on top of #85 

It does not seem to cause any problems to me, but I admit that I haven't tested it thoroughly. But I really like this feature, so if you think that it has a chance of making it into curl, I'll be happy to add a bunch of tests.

### EDIT: some test cases:

```r

## Delayed data

library(curl)
con <- curl("http://httpbin.org/delay/10")
open(con, blocking = FALSE)
readLines(con)

while (isIncomplete(con)) {
  Sys.sleep(0.1)
  readLines(con)
}

## Error code, unauthorized

library(curl)
con <- curl("http://httpbin.org/status/401")
open(con, blocking = FALSE)
readLines(con)

while (isIncomplete(con)) {
  Sys.sleep(0.1)
  readLines(con)
}

## Error, DNS failed

con <- curl("http://this.is.invalid")
open(con, blocking = FALSE)
readLines(con)

while (isIncomplete(con)) {
  Sys.sleep(0.1)
  readLines(con)
}

## Error, no such host, will timeout

con <- curl("http://240.0.0.1")
open(con, blocking = FALSE)
readLines(con)

while (isIncomplete(con)) {
  Sys.sleep(0.1)
  readLines(con)
}

## No HTTP on that port

con <- curl("http://8.8.8.8:666")
open(con, blocking = FALSE)
readLines(con)

while (isIncomplete(con)) {
  Sys.sleep(0.1)
  readLines(con)
}
```