### PR TITLE
Open connections in nonblocking

### DIFF
--- a/revdep/problems.md
+++ b/revdep/problems.md
@@ -4,30 +4,41 @@
 
 |setting  |value                        |
 |:--------|:----------------------------|
-|version  |R version 3.3.2 (2016-10-31) |
+|version  |R version 3.3.3 (2017-03-06) |
 |system   |x86_64, darwin13.4.0         |
 |ui       |X11                          |
 |language |(EN)                         |
 |collate  |en_US.UTF-8                  |
 |tz       |Europe/Amsterdam             |
-|date     |2016-11-23                   |
+|date     |2017-03-24                   |
 
 ## Packages
 
-|package |*  |version |date       |source                     |
-|:-------|:--|:-------|:----------|:--------------------------|
-|curl    |   |2.3     |2016-11-23 |local (jeroenooms/curl@NA) |
+|package |*  |version  |date       |source           |
+|:-------|:--|:--------|:----------|:----------------|
+|curl    |   |2.3.9000 |2017-03-24 |local (NA/NA@NA) |
 
 # Check results
+4 packages with problems
 
-2 packages with problems
+## biomartr (0.4.0)
+Maintainer: Hajk-Georg Drost <hgd23@cam.ac.uk>  
+Bug reports: https://github.com/HajkD/biomartr/issues
 
-|package    |version | errors| warnings| notes|
-|:----------|:-------|------:|--------:|-----:|
-|data.table |1.9.6   |      1|        0|     1|
-|smapr      |0.0.1   |      1|        0|     0|
+0 errors | 1 warning  | 0 notes
 
-## data.table (1.9.6)
+```
+checking re-building of vignette outputs ... WARNING
+Error in re-building vignettes:
+  ...
+Quitting from lines 29-31 (Database_Retrieval.Rmd) 
+Error: processing vignette 'Database_Retrieval.Rmd' failed with diagnostics:
+response reading failed
+Execution halted
+
+```
+
+## data.table (1.10.4)
 Maintainer: Matt Dowle <mattjdowle@gmail.com>  
 Bug reports: https://github.com/Rdatatable/data.table/issues
 
@@ -35,36 +46,83 @@ Bug reports: https://github.com/Rdatatable/data.table/issues
 
 ```
 checking tests ... ERROR
-Running the tests in ‘tests/tests.R’ failed.
+  Running ‘autoprint.R’
+  Comparing ‘autoprint.Rout’ to ‘autoprint.Rout.save’ ... OK
+  Running ‘knitr.R’
+  Comparing ‘knitr.Rout’ to ‘knitr.Rout.save’ ... OK
+  Running ‘main.R’ [118s/121s]
+Running the tests in ‘tests/main.R’ failed.
 Last 13 lines of output:
-  > y = with(DT, eval(ll)) 
-  First 6 of 644 :[1] 742 692 625 943 694 365
-  forder decreasing argument test: seed = 1479917387  colorder = 2,4,1,3,5 
-  Tests 1372.3+ not run. If required call library(GenomicRanges) first.
-  Tests 1441-1444 not run. If required install the 'fr_FR.utf8' locale.
+  Running test id 1696     Test 1751 ran without errors but failed check that x equals y:
+  > x = capture.output(fwrite(DT, verbose = FALSE))[-1] 
+  First 6 of 12 :[1] "1970-01-18T01:44:36.600000000Z" "1970-01-18T01:46:33.540000000Z"
+  [3] "1970-01-18T01:46:33.540000000Z" "1970-01-01T00:00:00.061000001Z"
+  [5] "1970-01-01T00:00:00.000000000Z" "1969-12-31T23:59:59.999999999Z"
+  > y = tt 
+  First 6 of 12 :[1] "2016-09-28T15:30:00.000000070Z" "2016-09-29T23:59:00.000000001Z"
+  [3] "2016-09-29T23:59:00.000000999Z" "1970-01-01T00:01:01.000001000Z"
+  [5] "1970-01-01T00:00:00.000000000Z" "1969-12-31T23:59:59.999999999Z"
+  10 string mismatches
   
   Error in eval(expr, envir, enclos) : 
-    14 errors out of 4390 (lastID=1557.4, endian=little, sizeof(long double)==16) in inst/tests/tests.Rraw on Wed Nov 23 17:09:55 2016. Search tests.Rraw for test numbers: 167, 167.2, 1253.152, 1253.156, 1253.232, 1253.234, 1253.24, 1253.242, 1253.264, 1253.272, 1253.424, 1253.428, 1253.44, 1253.444.
+    161 errors out of 5901 (lastID=1751, endian==little, sizeof(long double)==16, sizeof(pointer)==8) in inst/tests/tests.Rraw on Fri Mar 24 12:07:15 2017. Search tests.Rraw for test numbers: 1253.248, 1253.25, 1253.252, 1253.254, 1253.256, 1253.258, 1253.26, 1253.262, 1253.264, 1253.266, 1253.268, 1253.27, 1253.272, 1253.274, 1253.276, 1253.278, 1253.28, 1253.282, 1253.284, 1253.286, 1253.288, 1253.29, 1253.292, 1253.294, 1253.312, 1253.314, 1253.316, 1253.318, 1253.32, 1253.322, 1253.324, 1253.326, 1253.328, 1253.33, 1253.332, 1253.334, 1253.336, 1253.338, 1253.34, 1253.342, 1253.36, 1253.362, 1253.364, 1253.366, 1253.368, 1253.37, 1253.372, 1253.374, 1253.392, 1253.394, 1253.396, 1253.398, 1253.4, 1253.402, 1253.404, 1253.406, 1253.408, 1253.41, 1253.412, 1253.414, 1253.416, 1253.418, 1253.42, 1253.422, 1253.424, 1253.426, 1253.428, 1253.43, 1253.432, 1253.434, 1253.436, 1253.438, 1253.44, 1253.442, 1253.444, 1253.446, 1253.448, 1253.45, 1253.452, 1253.454, 1253.456, 1253.458,
   Calls: test.data.table -> sys.source -> eval -> eval
-  In addition: Warning message:
-  In library(package, lib.loc = lib.loc, character.only = TRUE, logical.return = TRUE,  :
-    there is no package called 'GenomicRanges'
   Execution halted
 
 checking package dependencies ... NOTE
 Package suggested but not available for checking: ‘GenomicRanges’
 ```
 
-## smapr (0.0.1)
-Maintainer: Maxwell Joseph <maxwell.b.joseph@colorado.edu>
+## geoknife (1.5.4)
+Maintainer: Jordan Read <jread@usgs.gov>  
+Bug reports: https://github.com/USGS-R/geoknife/issues
 
 1 error  | 0 warnings | 0 notes
 
 ```
-checking package dependencies ... ERROR
-Package required but not available: ‘rhdf5’
+checking tests ... ERROR
+  Running ‘testthat.R’
+Running the tests in ‘tests/testthat.R’ failed.
+Last 13 lines of output:
+  
+  The following object is masked from 'package:graphics':
+  
+      title
+  
+  The following object is masked from 'package:base':
+  
+      url
+  
+  Error in curl::curl_fetch_memory(url, handle = handle) : 
+    Server returned nothing (no headers, no data)
+  Calls: test_check ... request_fetch -> request_fetch.write_memory -> <Anonymous> -> .Call
+  testthat results ================================================================
+  OK: 32 SKIPPED: 19 FAILED: 0
+  Execution halted
+```
 
-See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
-manual.
+## textreadr (0.3.1)
+Maintainer: Tyler Rinker <tyler.rinker@gmail.com>  
+Bug reports: https://github.com/trinker/textreadr/issues?state=open
+
+1 error  | 0 warnings | 0 notes
+
+```
+checking examples ... ERROR
+Running examples in ‘textreadr-Ex.R’ failed
+The error most likely occurred in:
+
+> base::assign(".ptime", proc.time(), pos = "CheckExEnv")
+> ### Name: read_dir_transcript
+> ### Title: Read In Multiple Transcript Files From a Directory
+> ### Aliases: read_dir_transcript
+> 
+> ### ** Examples
+> 
+> skips <- c(0, 1, 1, 0, 0, 1)
+> path <- system.file("docs/transcripts", package = 'textreadr')
+> textreadr::peek(read_dir_transcript(path, skip = skips), Inf)
+R(44248,0x7fffbad4e3c0) malloc: *** error for object 0x10242e727: pointer being freed was not allocated
+*** set a breakpoint in malloc_error_break to debug
 ```
 

--- a/src/curl.c
+++ b/src/curl.c
@@ -187,7 +187,10 @@ void reset(Rconnection con) {
 
 static Rboolean rcurl_open(Rconnection con) {
   request *req = (request*) con->private;
-  //Rprintf("Opening URL:%s\n", req->url);
+
+  //same message as base::url()
+  if (con->mode[0] != 'r')
+    Rf_error("can only open URLs for reading");
 
   if(req->ref->locked)
     Rf_error("Handle is already in use elsewhere.");

--- a/src/curl.c
+++ b/src/curl.c
@@ -43,6 +43,7 @@ typedef struct {
   char *url;
   char *buf;
   char *cur;
+  int block_open;
   int has_data;
   int has_more;
   int used;
@@ -133,6 +134,8 @@ static size_t rcurl_read(void *target, size_t sz, size_t ni, Rconnection con) {
 #endif
     fetchdata(req);
     total_size += pop((char*)target + total_size, (req_size-total_size), req);
+    if(!req->block_open)
+      stop_for_status(req->handle);
     if(con->blocking == FALSE)
       break;
   }
@@ -207,9 +210,12 @@ static Rboolean rcurl_open(Rconnection con) {
   req->has_data = 0;
   req->has_more = 1;
 
+  /* fully non-blocking has 's' in open mode */
+  req->block_open = !strchr(con->mode, 's');
+
  /* Wait for first data to arrive. Monitoring a change in status code does not
    suffice in case of http redirects */
-  while(req->has_more && !req->has_data) {
+  while(req->block_open && req->has_more && !req->has_data) {
 #ifdef HAS_MULTI_WAIT
     int numfds;
     massert(curl_multi_wait(req->manager, NULL, 0, 1000, &numfds));
@@ -219,11 +225,12 @@ static Rboolean rcurl_open(Rconnection con) {
 
   /* check http status code */
   /* Stream connections should be checked via handle_data() */
-  if(!req->stream)
+  /* Non-blocking open connections get checked during read */
+  if(req->block_open && !req->stream)
     stop_for_status(handle);
 
   /* set mode in case open() changed it */
-  con->text = strcmp(con->mode, "rb") ? TRUE : FALSE;
+  con->text = strchr(con->mode, 'b') ? FALSE : TRUE;
   con->isopen = TRUE;
   con->incomplete = TRUE;
   return TRUE;

--- a/tests/testthat/test-blockopen.R
+++ b/tests/testthat/test-blockopen.R
@@ -1,0 +1,71 @@
+context("Non-blocking opening connection")
+
+read_text <- function(x){
+  while (isIncomplete(x)) {
+    Sys.sleep(0.1)
+    txt <- readLines(x)
+    if(length(txt))
+      return(txt)
+  }
+}
+
+read_bin <- function(x){
+  while (isIncomplete(x)) {
+    Sys.sleep(0.1)
+    bin <- readBin(x, raw(), 100)
+    if(length(bin))
+      return(bin)
+  }
+}
+
+expect_immediate <- function(...){
+  expect_true(system.time(...)['elapsed'] < 0.2)
+}
+
+test_that("Non-blocking open does not block", {
+
+  # Get a regular string
+  con <- curl(httpbin("delay/1"))
+  expect_immediate(open(con, "rs", blocking = FALSE))
+  expect_immediate(readLines(con))
+  close(con)
+})
+
+test_that("Error handling for non-blocking open", {
+
+  # Get a regular string
+  con <- curl(httpbin("get"))
+  expect_immediate(open(con, "rs", blocking = FALSE))
+  expect_is(read_text(con), "character")
+  close(con)
+
+  # Test error during read text
+  con <- curl(httpbin("status/401"))
+  expect_immediate(open(con, "rs", blocking = FALSE))
+  expect_error(read_text(con), "401")
+  close(con)
+
+  # Test error during read binary
+  con <- curl(httpbin("status/401"))
+  expect_immediate(open(con, "rbs", blocking = FALSE))
+  expect_error(read_bin(con), "401")
+  close(con)
+
+  # DNS error
+  con <- curl("http://this.is.invalid.co.za")
+  expect_immediate(open(con, "rs", blocking = FALSE))
+  expect_error(read_text(con), "resolve")
+  close(con)
+
+  # Non existing host
+  con <- curl("http://240.0.0.1")
+  expect_immediate(open(con, "rs", blocking = FALSE))
+  expect_error(read_text(con))
+  close(con)
+
+  # Invalid port
+  con <- curl("http://8.8.8.8:666")
+  expect_immediate(open(con, "rs", blocking = FALSE))
+  expect_error(read_text(con))
+  close(con)
+})


### PR DESCRIPTION
This allows to `open()` a connection without blocking the opening itself by setting an `s` in the mode.

It passes the test cases by @gaborcsardi though the state of `con` after the error is undefined.

```r
## Delayed data

library(curl)
con <- curl("http://httpbin.org/delay/10")
open(con, "rs", blocking = FALSE)
readLines(con)

while (isIncomplete(con)) {
  Sys.sleep(0.1)
  readLines(con)
}

## Error code, unauthorized

library(curl)
con <- curl("http://httpbin.org/status/401")
open(con, "rs", blocking = FALSE)
readLines(con)

while (isIncomplete(con)) {
  Sys.sleep(0.1)
  readLines(con)
}

## Error, DNS failed

con <- curl("http://this.is.invalid.co.nz")
open(con, "rs", blocking = FALSE)
readLines(con)

while (isIncomplete(con)) {
  Sys.sleep(0.1)
  readLines(con)
}

## Error, no such host, will timeout

con <- curl("http://240.0.0.1")
open(con, "rs", blocking = FALSE)
readLines(con)

while (isIncomplete(con)) {
  Sys.sleep(0.1)
  readLines(con)
}

## No HTTP on that port

con <- curl("http://8.8.8.8:666")
open(con, "rs", blocking = FALSE)
readLines(con)

while (isIncomplete(con)) {
  Sys.sleep(0.1)
  readLines(con)
}
```
