### PR TITLE
do not raise status-error when opened as non-blocking

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -134,8 +134,6 @@ static size_t rcurl_read(void *target, size_t sz, size_t ni, Rconnection con) {
 #endif
     fetchdata(req);
     total_size += pop((char*)target + total_size, (req_size-total_size), req);
-    if(!req->block_open)
-      stop_for_status(req->handle);
     if(con->blocking == FALSE)
       break;
   }

--- a/tests/testthat/test-blockopen.R
+++ b/tests/testthat/test-blockopen.R
@@ -40,15 +40,19 @@ test_that("Error handling for non-blocking open", {
   close(con)
 
   # Test error during read text
-  con <- curl(httpbin("status/401"))
+  h <- new_handle()
+  con <- curl(httpbin("status/418"), handle = h)
   expect_immediate(open(con, "rs", blocking = FALSE))
-  expect_error(read_text(con), "401")
+  expect_is(read_text(con), "character")
+  expect_equal(handle_data(h)$status_code, 418)
   close(con)
 
   # Test error during read binary
-  con <- curl(httpbin("status/401"))
+  h <- new_handle()
+  con <- curl(httpbin("status/418"), handle = h)
   expect_immediate(open(con, "rbs", blocking = FALSE))
-  expect_error(read_bin(con), "401")
+  expect_is(read_bin(con), "raw")
+  expect_equal(handle_data(h)$status_code, 418)
   close(con)
 
   # DNS error


### PR DESCRIPTION
@gaborcsardi would you be OK with this change?

The idea is that when performing a non-blocking `open()`, we do **not** raise an error for non-200 status code. This is to support use cases like https://github.com/jeroen/curl/issues/47 where the client wants to read the response text, even in case of an http error (e.g. a 400 error message). I think this makes sense.

So this means that when you open the connection as non blocking with the `s` parameter, you need to manually check the response status using `handle_data()`.  