### PR TITLE
Change reallocation pattern

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -67,13 +67,15 @@ static size_t push(void *contents, size_t sz, size_t nmemb, void *ctx) {
   size_t realsize = sz * nmemb;
   size_t newsize = req->size + realsize;
   if(newsize > req->limit) {
-    size_t newlimit = 2 * req->limit;
-    //Rprintf("Resizing buffer to %d.\n", newlimit);
-    void *newbuf = realloc(req->buf, newlimit);
+    // Author msquinn@google.com: Use newsize to set the new limit in realloc
+    // size_t newlimit = 2 * req->limit;
+    // Rprintf("Resizing buffer to %d.\n", newlimit);
+    void *newbuf = realloc(req->buf, newsize + 1);
     if(!newbuf)
       error("Failure in realloc. Out of memory?");
     req->buf = newbuf;
-    req->limit = newlimit;
+    // Author msquinn@google.com: Use newsize to set the new limit in realloc
+    req->limit += newsize + 1;
   }
 
   /* append new data */


### PR DESCRIPTION
The package has a memory stomping bug that appears with certain urls. This could be an artifact of having an older version of curl. I'm currently using 

curl 7.35.0 (x86_64-pc-linux-gnu) libcurl/7.35.0 OpenSSL/1.0.1f zlib/1.2.8 libidn/1.28 librtmp/2.3
Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtmp rtsp smtp smtps telnet tftp 
Features: AsynchDNS GSS-Negotiate IDN IPv6 Largefile NTLM NTLM_WB SSL libz TLS-SRP 


Here's a call that throws the bug:

  url <- "http://data.fis-ski.com/dynamic/results.html?sector=CC&raceid=22395"
  con <- curl(url)
  open(con)

This proposed reallocation pattern follows that of
https://github.com/collectd/collectd/blob/master/src/apache.c#L83