### PR TITLE
add CURLOPT_HTTP200ALIASES to set of curl_slist-requiring options

### DIFF
--- a/src/handle.c
+++ b/src/handle.c
@@ -173,6 +173,7 @@ int opt_is_linked_list(int key) {
     key == 10023 || // CURLOPT_HTTPHEADER
     key == 10024 || // CURLOPT_HTTPPOST
     key == 10070 || // CURLOPT_TELNETOPTIONS
+    key == 10104 || // CURLOPT_HTTP200ALIASES
     key == 10228;   // CURLOPT_PROXYHEADER
 }
 


### PR DESCRIPTION
as documented here:

   https://curl.haxx.se/libcurl/c/CURLOPT_HTTP200ALIASES.html

Otherwise, attempting to use this option causes a segfault because `curl_easy_setopt`
is being called with an R CHARSXP for the third parameter.