### PR TITLE
Make sure path has native encoding

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -29,7 +29,7 @@
 #' curl_download(url, tmp)
 #' }
 curl_download <- function(url, destfile, quiet = TRUE, mode = "wb", handle = new_handle()){
-  destfile <- normalizePath(destfile, mustWork = FALSE)
+  destfile <- enc2native(normalizePath(destfile, mustWork = FALSE))
   nonblocking <- isTRUE(getOption("curl_interrupt", TRUE))
   .Call(R_download_curl, url, destfile, quiet, mode, handle, nonblocking)
   invisible(destfile)

--- a/R/fetch.R
+++ b/R/fetch.R
@@ -71,7 +71,7 @@ curl_fetch_memory <- function(url, handle = new_handle()){
 #' @useDynLib curl R_curl_fetch_disk
 curl_fetch_disk <- function(url, path, handle = new_handle()){
   nonblocking <- isTRUE(getOption("curl_interrupt", TRUE))
-  path <- normalizePath(path, mustWork = FALSE)
+  path <- enc2native(normalizePath(path, mustWork = FALSE))
   output <- .Call(R_curl_fetch_disk, enc2utf8(url), handle, path, "wb", nonblocking)
   res <- handle_data(handle)
   res$content <- output

--- a/R/form.R
+++ b/R/form.R
@@ -10,7 +10,7 @@
 #' @name multipart
 #' @rdname multipart
 form_file <- function(path, type = NULL){
-  path <- normalizePath(path[1], mustWork = TRUE)
+  path <- enc2native(normalizePath(path[1], mustWork = TRUE))
   if(!is.null(type)){
     stopifnot(is.character(type))
   }

--- a/R/writer.R
+++ b/R/writer.R
@@ -24,7 +24,7 @@
 #' # Check it worked
 #' readLines(tmp)
 file_writer <- function(path){
-  path <- normalizePath(path, mustWork = FALSE)
+  path <- enc2native(normalizePath(path, mustWork = FALSE))
   fp <- new_file_writer(path)
   structure(function(data = raw(), close = FALSE){
     stopifnot(is.raw(data))

--- a/tests/testthat/test-path.R
+++ b/tests/testthat/test-path.R
@@ -1,0 +1,21 @@
+context("Paths")
+
+# https://github.com/jeroen/curl/issues/182
+test_that("curl_download() and curl_fetch_disk() can write to a non-ASCII path", {
+  ## chosen to be non-ASCII but
+  ## [1] representable in Windows-1252 and
+  ## [2] not any of the few differences between Windows-1252 and ISO-8859-1
+  ## a-grave + e-diaeresis  + Eth
+  tricky_filename <- "\u00C0\u00CB\u00D0"
+
+  tmpdir <- tempfile()
+  dir.create(tmpdir)
+  on.exit(unlink(tmpdir))
+
+  res <- curl_fetch_disk(httpbin("stream/10"), file.path(tmpdir, tricky_filename))
+  expect_true(file.exists(res$content))
+  unlink(list.files(tmpdir, full.names = TRUE))
+
+  res <- curl_download(httpbin("stream/10"), file.path(tmpdir, tricky_filename))
+  expect_true(file.exists(res))
+})


### PR DESCRIPTION
Fixes #182

If you are on board, I can add a test and apply the same `enc2native()` fix to other locations where it's needed.

This fixes the reprex I posted in #182 and, when curl is installed from this PR, fixes https://github.com/tidyverse/googledrive/issues/229.

``` r
library(curl)
destdir <- tempfile()
dir.create(destdir)
setwd(destdir)
res <- curl_fetch_disk("http://httpbin.org/stream/10", "äggplanta")
res$content
#> [1] "C:\\Users\\jenny\\AppData\\Local\\Temp\\RtmpSy9Rxd\\file27e87c9030d9\\äggplanta"
file.exists(res$content)
#> [1] TRUE
list.files()
#> [1] "äggplanta"
```

<sup>Created on 2019-04-27 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>


