### PR TITLE
Added domain to timeout message

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -45,6 +45,7 @@ void assert_status(CURLcode res, reference *ref){
   if(res == CURLE_OPERATION_TIMEDOUT) {
     const char *url = NULL;
     curl_easy_getinfo(ref->handle, CURLINFO_EFFECTIVE_URL, &url);
+    if (url==NULL) url = "CURLINFO_EFFECTIVE_URL==NULL";
     Rf_error("%s: %s: %s", curl_easy_strerror(res), ref->errbuf, url);
   }
   if(res != CURLE_OK)

--- a/src/utils.c
+++ b/src/utils.c
@@ -42,8 +42,11 @@ void assert(CURLcode res){
 }
 
 void assert_status(CURLcode res, reference *ref){
-  if(res == CURLE_OPERATION_TIMEDOUT)
-    Rf_error("%s: %s", curl_easy_strerror(res), ref->errbuf);
+  if(res == CURLE_OPERATION_TIMEDOUT) {
+    const char *url = NULL;
+    curl_easy_getinfo(ref->handle, CURLINFO_EFFECTIVE_URL, &url);
+    Rf_error("%s: %s: %s", curl_easy_strerror(res), ref->errbuf, url);
+  }
   if(res != CURLE_OK)
     Rf_error("%s", strlen(ref->errbuf) ? ref->errbuf : curl_easy_strerror(res));
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -84,8 +84,9 @@ void assert_status(CURLcode res, reference *ref){
         }
       }
     }
-    // fallback to a very plain simple error which does not use *url at all.
-    Rf_error("%s: %s: (hostname could not be safely extracted from URL)", curl_easy_strerror(res), ref->errbuf); // # nocov
+    // fallback to a very plain simple error which does not use *url at all (so no danger of including some of it)
+    Rf_error("%s: %s: (hostname could not be safely extracted from URL)",  // # nocov
+             curl_easy_strerror(res), ref->errbuf);                        // # nocov
   }
   if(res != CURLE_OK) {
     // in cases other than CURLE_OPERATION_TIMEDOUT, curl's own message includes the hostname already

--- a/src/utils.c
+++ b/src/utils.c
@@ -44,18 +44,24 @@ void assert(CURLcode res){
 void assert_status(CURLcode res, reference *ref){
   if(res == CURLE_OPERATION_TIMEDOUT) {
     // ref->errbuf contains "Resolving timed out after 1 milliseconds" in this case. Embellish this.
-    char *url = NULL, *host = NULL;
+    const char *url = NULL;
+    int len = 0;  // only output the hostname (strip long path and any authority)
     curl_easy_getinfo(ref->handle, CURLINFO_EFFECTIVE_URL, &url);
     if (url) {
-      CURLU* h = curl_url();
-      curl_url_set(h, CURLUPART_URL, url, 0);
-      curl_url_get(h, CURLUPART_HOST, &host, 0);
+      url = strchr(url, ':');
+      if (url) {
+        url++;
+        if (url[0]=='/' && url[1]=='/') url+=2;
+        char *w = strchr(url, '@');
+        if (w) url = w+1;
+        w = strchr(url, '/');
+        len = w ? w-url : strlen(url);
+      }
     }
-    Rf_error("%s: %s: %s", curl_easy_strerror(res), ref->errbuf, url ? host : "CURLINFO_EFFECTIVE_URL==NULL");
-    if (host) curl_free(host);
+    Rf_error("%s: %s: %.*s", curl_easy_strerror(res), ref->errbuf, len, url ? url : "");
   }
   if(res != CURLE_OK) {
-    Rf_error("res=%d, strlen(errbuf)=%d: %s", res, strlen(ref->errbuf), strlen(ref->errbuf) ? ref->errbuf : curl_easy_strerror(res));
+    Rf_error("%s", strlen(ref->errbuf) ? ref->errbuf : curl_easy_strerror(res));
     // e.g. res==7 (CURLE_COULDNT_CONNECT), ref->errbuf contains "Failed to connect to www.google.com port 81: Connection timed out"
   }
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -50,11 +50,11 @@ void assert_status(CURLcode res, reference *ref){
     curl_easy_getinfo(ref->handle, CURLINFO_EFFECTIVE_URL, &url);
     if (url && (
         strncmp(url, "http://", 7)==0 ||
-        strncmp(url, "HTTP://", 7)==0 ||
-        strncmp(url, "https://", 8)==0 ||
-        strncmp(url, "HTTPS://", 8)==0 ||
-        strncmp(url, "ftp://", 6)==0 ||
-        strncmp(url, "FTP://", 6)==0)) {
+        strncmp(url, "HTTP://", 7)==0 ||  // # nocov
+        strncmp(url, "https://", 8)==0 || // # nocov
+        strncmp(url, "HTTPS://", 8)==0 || // # nocov
+        strncmp(url, "ftp://", 6)==0 ||   // # nocov
+        strncmp(url, "FTP://", 6)==0)) {  // # nocov
       // only attempt to extract hostname from this strict subset of known schemes for
       // safety to avoid leaking non-hostname data to error message and log
       url = strchr(url, ':') + 3;  // we're sure by now that that :// exists
@@ -85,7 +85,7 @@ void assert_status(CURLcode res, reference *ref){
       }
     }
     // fallback to a very plain simple error which does not use *url at all.
-    Rf_error("%s: %s: (hostname could not be safely extracted from URL)", curl_easy_strerror(res), ref->errbuf);
+    Rf_error("%s: %s: (hostname could not be safely extracted from URL)", curl_easy_strerror(res), ref->errbuf); // # nocov
   }
   if(res != CURLE_OK) {
     // in cases other than CURLE_OPERATION_TIMEDOUT, curl's own message includes the hostname already


### PR DESCRIPTION
Closes #190 
Before this PR I could reproduce the timeout as follows : 
```R
> url <- "http://www.r-project.org"
> require(curl)
Loading required package: curl
> h <- new_handle()
> handle_setopt(h, connecttimeout_ms = 1L)
> curl_fetch_memory(url, h)
Error in curl_fetch_memory(url, h) : 
  Timeout was reached: Connection timed out after 1 milliseconds
```
with this PR, the new behavior is:
```R
> curl_fetch_memory(url, h)
Error in curl_fetch_memory(url, h) : 
  Timeout was reached: Connection timed out after 1 milliseconds: http://www.r-project.org/
```
Thanks to @krlmlr for the tip in the issue as to where to make this change.