### PR TITLE
More flexible DNS look-up in has_internet

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,6 +36,6 @@ VignetteBuilder: knitr
 Depends:
     R (>= 3.0.0)
 LazyData: true
-RoxygenNote: 7.0.1
+RoxygenNote: 7.1.0
 Encoding: UTF-8
 Language: en-US

--- a/R/nslookup.R
+++ b/R/nslookup.R
@@ -34,18 +34,20 @@ nslookup <- function(host, ipv4_only = FALSE, multiple = FALSE, error = TRUE){
 }
 
 #' @export
+#' @param expected_addr character vector of expected ipv4 addresses corresponding
+#'     to \code{host}, of at least one should match the output of \code{nslookup}
 #' @rdname nslookup
 has_internet <- local({
   proxy_vars_previous <- NULL
   has_internet_via_proxy <- NULL
-  function(host="dns.google.com"){
+  function(host="dns.google.com", expected_addr=c("8.8.4.4", "8.8.8.8")){
     # do not wait for nslookup() if we know proxy works
     if(isTRUE(has_internet_via_proxy))
       return(TRUE)
 
     # Method 1: try DNS lookup. May resolve to 8.8.8.8 or 8.8.4.4
     ip_addr <- nslookup(host, multiple = TRUE, error = FALSE, ipv4_only = TRUE)
-    if(any(c("8.8.4.4", "8.8.8.8") %in% ip_addr))
+    if(any(expected_addr %in% ip_addr))
       return(TRUE)
 
     # Method 2: look for a proxy server

--- a/R/nslookup.R
+++ b/R/nslookup.R
@@ -38,13 +38,13 @@ nslookup <- function(host, ipv4_only = FALSE, multiple = FALSE, error = TRUE){
 has_internet <- local({
   proxy_vars_previous <- NULL
   has_internet_via_proxy <- NULL
-  function(){
+  function(host="dns.google.com"){
     # do not wait for nslookup() if we know proxy works
     if(isTRUE(has_internet_via_proxy))
       return(TRUE)
 
     # Method 1: try DNS lookup. May resolve to 8.8.8.8 or 8.8.4.4
-    ip_addr <- nslookup('dns.google.com', multiple = TRUE, error = FALSE, ipv4_only = TRUE)
+    ip_addr <- nslookup(host, multiple = TRUE, error = FALSE, ipv4_only = TRUE)
     if(any(c("8.8.4.4", "8.8.8.8") %in% ip_addr))
       return(TRUE)
 

--- a/man/nslookup.Rd
+++ b/man/nslookup.Rd
@@ -7,7 +7,7 @@
 \usage{
 nslookup(host, ipv4_only = FALSE, multiple = FALSE, error = TRUE)
 
-has_internet()
+has_internet(host = "dns.google.com")
 }
 \arguments{
 \item{host}{a string with a hostname}

--- a/man/nslookup.Rd
+++ b/man/nslookup.Rd
@@ -7,7 +7,7 @@
 \usage{
 nslookup(host, ipv4_only = FALSE, multiple = FALSE, error = TRUE)
 
-has_internet(host = "dns.google.com")
+has_internet(host = "dns.google.com", expected_addr = c("8.8.4.4", "8.8.8.8"))
 }
 \arguments{
 \item{host}{a string with a hostname}
@@ -17,6 +17,9 @@ has_internet(host = "dns.google.com")
 \item{multiple}{returns multiple ip addresses if possible}
 
 \item{error}{raise an error for failed DNS lookup. Otherwise returns \code{NULL}.}
+
+\item{expected_addr}{character vector of expected ipv4 addresses corresponding
+to \code{host}, of at least one should match the output of \code{nslookup}}
 }
 \description{
 The \code{nslookup} function is similar to \code{nsl} but works on all platforms


### PR DESCRIPTION
`has_internet` does a hard-coded DNS lookup against Google, which seems to fail for at least some users in locations where Google is not directly accessible (see [here](https://github.com/LTLA/SingleR/issues/109#issuecomment-614751435)).

This PR proposes to allow for DNS look-ups to other locations inside the `has_internet` function. The rationale is that, at least in the case of the Bioconductor **ExperimentHub** package, we only really need access to `experimenthub.bioconductor.org`; the availability of Google's DNS servers is not the most relevant measure of connectivity. (The same could be said for the Apple address later on, but I don't know too much about what that does, so I didn't touch it.)

This [thread](https://github.com/Bioconductor/ExperimentHub/pull/13#discussion_r409446816) may be useful to provide some additional context for this PR.