### PR TITLE
Adding shebang support

### DIFF
--- a/configure
+++ b/configure
@@ -1,3 +1,4 @@
+#!/bin/sh
 # Anticonf (tm) script by Jeroen Ooms (2019)
 # This script will query 'pkg-config' for the required cflags and ldflags.
 # If pkg-config is unavailable or does not find the library, try setting


### PR DESCRIPTION
I've just added the shebang notation in the configure file to avoid build errors when running Docker's Buildx multiarch builds in Alpine-based images. Unfortunately, this happens in every shell script file that doesn't provide this notation.

Thanks for the amazing package :)