### PR TITLE
src/curl.c: Fix BSWAP_32 for the benefit of BE NetBSD hosts.

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -24,6 +24,10 @@
 #define BSWAP_32 OSSwapInt32
 #elif (defined(__OpenBSD__))
 #define BSWAP_32(x) swap32(x)
+#elif (defined(__NetBSD__))
+#include <sys/types.h>
+#include <machine/bswap.h>
+#define BSWAP_32(x) bswap32(x)
 #elif (defined(__GLIBC__))
 #include <byteswap.h>
 #define BSWAP_32(x) bswap_32(x)


### PR DESCRIPTION
This fixes this to build + install on big-endian NetBSD hosts,
such as NetBSD/macppc (a powerpc port).
