### PR TITLE
add test for a ssl3 problem

### DIFF
--- a/tests/testthat/test-ssl3.R
+++ b/tests/testthat/test-ssl3.R
@@ -1,0 +1,6 @@
+context("SSL3 rpoblem")
+
+test_that("problem due to SSL3 does not happen", {
+  skip_on_cran()
+  req <- curl::curl_fetch_memory('http://rest.kegg.jp/conv/ncbi-geneid/dme')
+})


### PR DESCRIPTION
trying to add a test case for a URL that gives me problems (fails also when executing `curl http://rest.kegg.jp/conv/ncbi-geneid/dme -L` on my ubuntu machine .. so the problem might sit deeper): 

```
curl: (56) OpenSSL SSL_read: error:0A000126:SSL routines::unexpected eof while reading, errno 0
```

xref https://github.com/conda-forge/r-curl-feedstock/pull/21

not sure if I'm doing this right .. I'm quite new to `testthat` (but keen on learning by doing) and R is not my primary language.

