### PR TITLE
Update multi_download() arguments to make it more flexible

### DIFF
--- a/R/multi_download.R
+++ b/R/multi_download.R
@@ -10,7 +10,7 @@
 #' of the HTTP status code). If it failed, e.g. due to a networking issue, the error
 #' message is in the `error` column. A `success` value `NA` indicates that the request
 #' was still in progress when the function was interrupted or reached the elapsed
-#' `timeout` and perhaps the download can be resumed if the server supports it.
+#' `multi_timeout` and perhaps the download can be resumed if the server supports it.
 #'
 #' It is also important to inspect the `status_code` column to see if any of the
 #' requests were successful but had a non-success HTTP code, and hence the downloaded
@@ -66,7 +66,7 @@
 #' or `NULL` to use [basename] of urls.
 #' @param resume if the file already exists, resume the download. Note that this may
 #' change server responses, see details.
-#' @param timeout in seconds, passed to [multi_run]
+#' @param multi_timeout in seconds, passed to [multi_run]
 #' @param progress print download progress information
 #' @param pool a multi handle created by \link{new_pool}.
 #'   Default is to use [new_pool(multiplex = FALSE)].
@@ -102,7 +102,7 @@
 #'
 #' }
 multi_download <- function(urls, destfiles = NULL, resume = FALSE, progress = TRUE,
-                           timeout = Inf, pool = NULL, ...){
+                           multi_timeout = Inf, pool = NULL, ...){
   urls <- enc2utf8(urls)
   if(is.null(destfiles)){
     destfiles <- basename(sub("[?#].*", "", urls))
@@ -173,7 +173,7 @@ multi_download <- function(urls, destfiles = NULL, resume = FALSE, progress = TR
     writer(raw(0), close = TRUE)
   }))
   tryCatch({
-    multi_run(timeout = timeout, pool = pool)
+    multi_run(timeout = multi_timeout, pool = pool)
     if(isTRUE(progress)){
       print_progress(success, total, sum(dlspeed), sum(expected), TRUE)
     }

--- a/R/multi_download.R
+++ b/R/multi_download.R
@@ -68,7 +68,8 @@
 #' change server responses, see details.
 #' @param timeout in seconds, passed to [multi_run]
 #' @param progress print download progress information
-#' @param multiplex passed to [new_pool]
+#' @param pool a multi handle created by \link{new_pool}.
+#'   Default is to use [new_pool(multiplex = FALSE)].
 #' @param ... extra handle options passed to each request [new_handle]
 #' @examples \dontrun{
 #' # Example: some large files
@@ -101,7 +102,7 @@
 #'
 #' }
 multi_download <- function(urls, destfiles = NULL, resume = FALSE, progress = TRUE,
-                           timeout = Inf, multiplex = FALSE, ...){
+                           timeout = Inf, pool = NULL, ...){
   urls <- enc2utf8(urls)
   if(is.null(destfiles)){
     destfiles <- basename(sub("[?#].*", "", urls))
@@ -119,7 +120,9 @@ multi_download <- function(urls, destfiles = NULL, resume = FALSE, progress = TR
   resumefrom <- rep(0, length(urls))
   dlspeed <- rep(0, length(urls))
   expected <- rep(NA, length(urls))
-  pool <- new_pool(multiplex = multiplex)
+  if (is.null(pool)) {
+    pool <- new_pool(multiplex = FALSE)
+  }
   total <- 0
   lapply(seq_along(urls), function(i){
     dest <- destfiles[i]

--- a/man/multi_download.Rd
+++ b/man/multi_download.Rd
@@ -10,7 +10,7 @@ multi_download(
   resume = FALSE,
   progress = TRUE,
   timeout = Inf,
-  multiplex = FALSE,
+  pool = NULL,
   ...
 )
 }
@@ -27,7 +27,8 @@ change server responses, see details.}
 
 \item{timeout}{in seconds, passed to \link{multi_run}}
 
-\item{multiplex}{passed to \link{new_pool}}
+\item{pool}{a multi handle created by \link{new_pool}.
+Default is to use \link{new_pool(multiplex = FALSE)}.}
 
 \item{...}{extra handle options passed to each request \link{new_handle}}
 }

--- a/man/multi_download.Rd
+++ b/man/multi_download.Rd
@@ -9,7 +9,7 @@ multi_download(
   destfiles = NULL,
   resume = FALSE,
   progress = TRUE,
-  timeout = Inf,
+  multi_timeout = Inf,
   pool = NULL,
   ...
 )
@@ -25,7 +25,7 @@ change server responses, see details.}
 
 \item{progress}{print download progress information}
 
-\item{timeout}{in seconds, passed to \link{multi_run}}
+\item{multi_timeout}{in seconds, passed to \link{multi_run}}
 
 \item{pool}{a multi handle created by \link{new_pool}.
 Default is to use \link{new_pool(multiplex = FALSE)}.}
@@ -66,7 +66,7 @@ The \code{success} column indicates if a request was successfully completed (reg
 of the HTTP status code). If it failed, e.g. due to a networking issue, the error
 message is in the \code{error} column. A \code{success} value \code{NA} indicates that the request
 was still in progress when the function was interrupted or reached the elapsed
-\code{timeout} and perhaps the download can be resumed if the server supports it.
+\code{multi_timeout} and perhaps the download can be resumed if the server supports it.
 
 It is also important to inspect the \code{status_code} column to see if any of the
 requests were successful but had a non-success HTTP code, and hence the downloaded

--- a/man/multi_download.Rd
+++ b/man/multi_download.Rd
@@ -11,6 +11,8 @@ multi_download(
   progress = TRUE,
   multi_timeout = Inf,
   pool = NULL,
+  max_retries = 0,
+  retry_status_codes = NULL,
   ...
 )
 }
@@ -29,6 +31,18 @@ change server responses, see details.}
 
 \item{pool}{a multi handle created by \link{new_pool}.
 Default is to use \link{new_pool(multiplex = FALSE)}.}
+
+\item{max_retries}{The maximum number of retry attempts for each download.
+If a download fails due to a network issue or receives an HTTP status code
+specified in \code{retry_status_codes}, it will be retried up to \code{max_retries} times
+before giving up. The default value is 0.}
+
+\item{retry_status_codes}{A vector of HTTP status codes that should trigger
+a retry of the download. Only these specified status codes will lead to
+a retry, in addition to any network failures. Common codes for retry might
+include 500 (Internal Server Error), 502 (Bad Gateway), 503 (Service Unavailable),
+and 504 (Gateway Timeout). The default value is \code{NULL}
+(i.e. no retry attempts for non-zero status codes).}
 
 \item{...}{extra handle options passed to each request \link{new_handle}}
 }

--- a/src/handle.c
+++ b/src/handle.c
@@ -136,10 +136,9 @@ static void set_handle_defaults(reference *ref){
   curl_easy_setopt(handle, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NO_REVOKE);
   struct curl_tlssessioninfo *tlsinfo = NULL;
   if(curl_easy_getinfo(handle, CURLINFO_TLS_SSL_PTR, &tlsinfo) == CURLE_OK){
-    if(tlsinfo->backend == CURLSSLBACKEND_OPENSSL && ca_bundle == NULL) {
-      curl_easy_setopt(handle, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NO_REVOKE | CURLSSLOPT_NATIVE_CA);
-    } else if(tlsinfo->backend == CURLSSLBACKEND_SCHANNEL){
+    if(tlsinfo->backend == CURLSSLBACKEND_SCHANNEL) {
       ca_bundle = NULL;
+      curl_easy_setopt(handle, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NO_REVOKE | CURLSSLOPT_NATIVE_CA);
     }
   }
   #endif


### PR DESCRIPTION
Removed `multiplex` argument and added `pool` argument to allow users to pass a pool object directly. Closes #322.

Renamed `timeout` argument to `multi_timeout` so it doesn't clash with handle options.  Closes #296.