### PR TITLE
Default to CURLOPT_UNRESTRICTED_AUTH = 0

### DIFF
--- a/src/handle.c
+++ b/src/handle.c
@@ -172,7 +172,7 @@ static void set_handle_defaults(reference *ref){
 
   /* allow all authentication methods */
   assert(curl_easy_setopt(handle, CURLOPT_HTTPAUTH, CURLAUTH_ANY));
-  assert(curl_easy_setopt(handle, CURLOPT_UNRESTRICTED_AUTH, 1L));
+  assert(curl_easy_setopt(handle, CURLOPT_UNRESTRICTED_AUTH, 0L));
   assert(curl_easy_setopt(handle, CURLOPT_PROXYAUTH, CURLAUTH_ANY));
 
   /* enables HTTP2 on HTTPS (match behavior of curl cmd util) */


### PR DESCRIPTION
Resolves #260 and perhaps r-lib/httr#626 