### PR TITLE
Fix #329: make rcurl_read() return without waiting if non-blocking

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: curl
 Type: Package
 Title: A Modern and Flexible Web Client for R
-Version: 5.2.0
+Version: 5.2.1
 Authors@R: c(
     person("Jeroen", "Ooms", role = c("aut", "cre"), email = "jeroen@berkeley.edu",
       comment = c(ORCID = "0000-0002-4035-0289")),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+5.2.1
+ - Fix an issue where curl_fetch_stream() might not return all bytes received
+   by the C layer if the server closed the connection mid-response.
+
 5.2.0
  - The CURL_CA_BUNDLE envvar is now also used on non-Windows.
  - curl_echo() now uses a random available port to run httpuv


### PR DESCRIPTION
Fix #329: in the streaming or non-blocking case, have `rcurl_read()` return any buffered bytes immediately before attempting to fetch more from the remote server. This way, even if the subsequent fetch fails due to the server closing the connection, the application has access to the bytes already sent by the server and buffered inside the R client's C code.