### PR TITLE
Enable sending blank request headers

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,7 @@
 5.2.1
+ - In handle_setheader(), setting a header to a non-empty whitespace string will
+   now send a blank header. Using an empty string will still remove the header
+   altogether (this has not changed).
  - Fix an issue where curl_fetch_stream() might not return all bytes received
    by the C layer if the server closed the connection mid-response.
  - No longer enable CURLOPT_UNRESTRICTED_AUTH by default

--- a/R/handle.R
+++ b/R/handle.R
@@ -80,8 +80,9 @@ handle_setheaders <- function(handle, ..., .list = list()){
   opts$Expect = ""
   names <- names(opts)
   values <- as.character(unlist(opts))
-  vec <- paste0(names, ": ", values)
-  .Call(R_handle_setheaders, handle, vec)
+  postfix <- ifelse(grepl("^\\s+$", values), ";", paste(":", values))
+  headers <- paste0(names, postfix)
+  .Call(R_handle_setheaders, handle, headers)
   invisible(handle)
 }
 

--- a/tests/testthat/test-handle.R
+++ b/tests/testthat/test-handle.R
@@ -103,6 +103,16 @@ test_that("setting request headers", {
   expect_length(curl:::handle_getheaders(h), 0)
 })
 
+
+test_that("Set blank and NULL headers", {
+  skip_if_not_installed('httpuv')
+  skip_if_not_installed('webutils')
+  h <- new_handle(url = 'https://httpbin.org/get')
+  handle_setheaders(h, "accept-encoding" = "", "accept" = "", "user-agent" = "", foo = " ", bar = "\t")
+  req <- curl::curl_echo(h)
+  expect_equal(req$headers, c(bar = "", foo = "", host = "httpbin.org"))
+})
+
 test_that("Custom vector options", {
   h <- new_handle()
   x <- c("foo@gmail.com", "bar@jkhk.nl")


### PR DESCRIPTION
Fixes https://github.com/r-lib/httr2/issues/428