### PR TITLE
Windows openssl

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,14 +24,13 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-12,   r: 'oldrel'}
-          - {os: macOS-12,   r: 'oldrel', ssl-backend: SecureTransport}
           - {os: macOS-13,   r: 'release'}
           - {os: macOS-13,   r: 'release', ssl-backend: SecureTransport}
           - {os: macOS-14,   r: 'release'}
           - {os: macOS-14,   r: 'release', ssl-backend: SecureTransport}
+          - {os: windows-latest, r: 'devel'}
           - {os: windows-latest, r: 'release', ssl-backend: openssl}
-          - {os: windows-latest, r: 'release'}
+          - {os: windows-latest, r: 'release', ssl-backend: schannel}
           - {os: windows-latest, r: '4.2'}
           - {os: windows-latest, r: '4.1', ssl-backend: openssl}
           - {os: windows-latest, r: '4.1'}

--- a/src/init.c
+++ b/src/init.c
@@ -88,11 +88,11 @@ static const R_CallMethodDef CallEntries[] = {
     {NULL, NULL, 0}
 };
 
-void switch_to_openssl_on_vista(void);
+void select_tls_backend(void);
 CURLM *shared_multi_handle = NULL;
 
 attribute_visible void R_init_curl(DllInfo *info) {
-  switch_to_openssl_on_vista();
+  select_tls_backend();
   curl_global_init(CURL_GLOBAL_DEFAULT);
   shared_multi_handle = curl_multi_init();
   R_registerRoutines(info, NULL, CallEntries, NULL, NULL);

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -1,15 +1,7 @@
-#include <curl/curl.h>
-#include <Rinternals.h>
+#include "curl-common.h"
 
-#if LIBCURL_VERSION_MAJOR > 7 || (LIBCURL_VERSION_MAJOR == 7 && LIBCURL_VERSION_MINOR >= 56)
-#define HAS_MULTI_SSL 1
-#endif
-
-/* Force OpenSSL on Legacy Windows (Vista/2008) which do not support TLS 1.2 natively.
- * On other systems we let libcurl choose so you can set the 'CURL_SSL_BACKEND' variable.
- */
-void switch_to_openssl_on_vista(void){
-#if defined(_WIN32) && defined(HAS_MULTI_SSL)
+void select_tls_backend(void){
+#if defined(_WIN32) && AT_LEAST_CURL(8,0)
   /* If a CURL_SSL_BACKEND is set, do not override */
   char *envvar = getenv("CURL_SSL_BACKEND");
   if(envvar != NULL && *envvar != 0){
@@ -17,15 +9,8 @@ void switch_to_openssl_on_vista(void){
     return;
   }
 
-  /* Lookup Windows version */
-  DWORD dwBuild = 0;
-  DWORD dwVersion = GetVersion();
-  if (dwVersion < 0x80000000)
-    dwBuild = (DWORD)(HIWORD(dwVersion));
-
-  /* TLS 1.2 requires at least Windows 7 or 2008-R2 */
-  if(dwBuild < 7600){
-    switch(curl_global_sslset(CURLSSLBACKEND_OPENSSL, NULL, NULL)){
+  /* Default to using OpenSSL (which supports http/2) */
+  switch(curl_global_sslset(CURLSSLBACKEND_OPENSSL, NULL, NULL)){
     case CURLSSLSET_OK :
       break;
     case CURLSSLSET_TOO_LATE:

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -4,13 +4,13 @@ void select_tls_backend(void){
 #if defined(_WIN32) && AT_LEAST_CURL(8,0)
   /* If a CURL_SSL_BACKEND is set, do not override */
   char *envvar = getenv("CURL_SSL_BACKEND");
-  if(envvar != NULL && *envvar != 0){
+  if(envvar != NULL && *envvar != 0) {
     REprintf("Initiating curl with CURL_SSL_BACKEND: %s\n", envvar);
     return;
   }
 
   /* Default to using OpenSSL (which supports http/2) */
-  switch(curl_global_sslset(CURLSSLBACKEND_OPENSSL, NULL, NULL)){
+  switch(curl_global_sslset(CURLSSLBACKEND_OPENSSL, NULL, NULL)) {
     case CURLSSLSET_OK :
       break;
     case CURLSSLSET_TOO_LATE:
@@ -22,7 +22,6 @@ void select_tls_backend(void){
     default:
       Rf_warning("Failed to set libcurl SSL: unknown error");
       break;
-    }
   }
 
 #endif

--- a/tests/testthat/test-handle.R
+++ b/tests/testthat/test-handle.R
@@ -145,11 +145,12 @@ test_that("Error classes", {
 
 test_that("Platform specific features", {
   if(.Platform$OS.type == 'windows'){
-    ssl_version <- curl_version()$ssl_version
-    if(get_windows_build() < 7600 || grepl("openssl", Sys.getenv('CURL_SSL_BACKEND'), TRUE)){
-      expect_match(ssl_version, "OpenSSL.*\\(Schannel\\)")
-    } else {
+    ver <- curl_version()
+    ssl_version <- ver$ssl_version
+    if(grepl("schannel", Sys.getenv('CURL_SSL_BACKEND'), TRUE)){
       expect_match(ssl_version, "\\(OpenSSL.*\\) Schannel")
+    } else {
+      expect_match(ssl_version, "OpenSSL.*\\(Schannel\\)")
     }
   } else if(!is.na(curl_options()['unix_socket_path'])){
     # This should simply not error

--- a/tests/testthat/test-handle.R
+++ b/tests/testthat/test-handle.R
@@ -147,7 +147,7 @@ test_that("Platform specific features", {
   if(.Platform$OS.type == 'windows'){
     ver <- curl_version()
     ssl_version <- ver$ssl_version
-    if(grepl("schannel", Sys.getenv('CURL_SSL_BACKEND'), TRUE)){
+    if(grepl("schannel", Sys.getenv('CURL_SSL_BACKEND'), TRUE) || compareVersion(ver$version, '8') == -1){
       expect_match(ssl_version, "\\(OpenSSL.*\\) Schannel")
     } else {
       expect_match(ssl_version, "OpenSSL.*\\(Schannel\\)")


### PR DESCRIPTION
Consider switching to OpenSSL as default on Windows?

Problem: R sets a variable `CURL_CA_BUNDLE` by default to a legacy bundle. We should avoid that probably.