### PR TITLE
Support event-driven streaming async using curl connections

### DIFF
--- a/R/multi.R
+++ b/R/multi.R
@@ -199,6 +199,7 @@ print.curl_multi <- function(x, ...){
 multi_fdset <- function(pool = NULL){
   if(is.null(pool))
     pool <- multi_default()
-  stopifnot(inherits(pool, "curl_multi"))
+  # line below duplicates checks made by C code, but may need to be reinstated if that ever changes
+  # stopifnot(inherits(pool, c("curl_multi", "curl")))
   .Call(R_multi_fdset, pool)
 }

--- a/src/curl.c
+++ b/src/curl.c
@@ -290,6 +290,9 @@ SEXP R_curl_connection(SEXP url, SEXP ptr, SEXP partial) {
   /* protect the handle */
   (req->ref->refCount)++;
 
+  /* store the CURLM address in con->ex_ptr which is the 'conn_id' attribute */
+  R_SetExternalPtrAddr((SEXP) con->ex_ptr, req->manager);
+
   UNPROTECT(1);
   return rc;
 }

--- a/src/multi.c
+++ b/src/multi.c
@@ -15,6 +15,23 @@ multiref *get_multiref(SEXP ptr){
   return mref;
 }
 
+/* retrieves CURLM from connections as well as pools */
+CURLM *get_curlm(SEXP ptr){
+  CURLM *multi;
+  if(Rf_inherits(ptr, "curl")){
+    ptr = Rf_getAttrib(ptr, Rf_install("conn_id"));
+    if (TYPEOF(ptr) != EXTPTRSXP)
+      Rf_error("pool ptr is not a curl connection");
+    multi = (CURLM*) R_ExternalPtrAddr(ptr);
+    if(!multi)
+      Rf_error("CURLM pointer is dead");
+  } else {
+    multiref *mref = get_multiref(ptr);
+    multi = mref->m;
+  }
+  return multi;
+}
+
 void multi_release(reference *ref){
   /* Release the easy-handle */
   CURL *handle = ref->handle;
@@ -247,8 +264,7 @@ SEXP R_multi_list(SEXP pool_ptr){
 }
 
 SEXP R_multi_fdset(SEXP pool_ptr){
-  multiref *mref =  get_multiref(pool_ptr);
-  CURLM *multi = mref->m;
+  CURLM *multi = get_curlm(pool_ptr);
   fd_set read_fd_set, write_fd_set, exc_fd_set;
   int max_fd, i, num_read = 0, num_write = 0, num_exc = 0;
   int *pread, *pwrite, *pexc;

--- a/tests/testthat/test-connection.R
+++ b/tests/testthat/test-connection.R
@@ -35,3 +35,13 @@ test_that("Connection interface", {
   expect_equal(handle_data(h)$status_code, 418L)
   close(con) #destroy
 })
+
+test_that("Can retrieve fds from a connection", {
+  con <- curl(httpbin("get?test=blabla"), handle = h)
+  fds <- multi_fdset(con)
+  expect_type(fds, "list")
+  close(con)
+  not <- "not a connection"
+  class(not) <- "curl"
+  expect_error(multi_fdset(not))
+})


### PR DESCRIPTION
Hi Jeroen,

This PR provides minimal changes so that packages such as `elmer` can continue using curl connections for streaming whilst adopting event-driven async using `later::later_fd()`, which efficiently polls sockets returned by `curl::multi_fdset()`.

It is a prerequisite for https://github.com/tidyverse/elmer/pull/158.

You'll be familiar with the issue facing us, summarized below:
1. `curl::curl()` returns an R connection object which does not contain any reference to the underlying C `struct Rconn` (RConnection).
2. The R connection object does have an external pointer as attribute 'conn_id', but this contains the address to an integer _pointer_, from which we cannot get the `struct Rconn` address.
3. As the curl CURLM handle is stored in the `struct Rconn`, this remains inaccessible for us.

This PR solves this in the following way:

- When the R connection object is created, the external pointer address of the 'conn_id' attribute is set to the CURLM handle (this value is never accessed by R itself after checking with the sources).
- A new helper function retrieves the CURLM handle from both pools and connections for `curl::multi_fdset()`.

The approach taken here is likely going to be the most efficient, but we've tried our best to be considerate and will give you the luxury of choosing between this and another PR which doesn't modify the existing functions at all.

These PRs have been reviewed by both @hadley and @jcheng5.

Thanks.

Closes #357.