### PR TITLE
Allow open(curl(url)) to be interrupted

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@
  - Fix a rchk bug
  - Enable CURLOPT_PIPEWAIT by default to prefer multiplex when possible
  - Enable setting max_streams in multi_set(), default to 10
+ - Allow open(curl::curl()) to be interrupted
 
 6.0.1
  - Fix a build issue with libcurl 8.11.0

--- a/src/curl.c
+++ b/src/curl.c
@@ -224,6 +224,7 @@ static Rboolean rcurl_open(Rconnection con) {
   while(block_open && req->has_more && !req->has_data) {
     int numfds;
     massert(curl_multi_wait(req->manager, NULL, 0, 1000, &numfds));
+    R_CheckUserInterrupt();
     massert(curl_multi_perform(req->manager, &(req->has_more)));
     for(int msg = 1; msg > 0;){
       CURLMsg *out = curl_multi_info_read(req->manager, &msg);


### PR DESCRIPTION
Fixes https://github.com/jeroen/curl/issues/363

I'm not sure if this is right... for example, do I need to make sure `reset(con)` is called?