### PR TITLE
Re-throw interrupts

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: curl
 Type: Package
 Title: A Modern and Flexible Web Client for R
-Version: 6.0.2
+Version: 6.1.0
 Authors@R: c(
     person("Jeroen", "Ooms", role = c("aut", "cre"), email = "jeroenooms@gmail.com",
       comment = c(ORCID = "0000-0002-4035-0289")),

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-6.0.2
+6.1.0
  - Fix a rchk bug
  - Enable CURLOPT_PIPEWAIT by default to prefer multiplex when possible
  - Enable setting max_streams in multi_set(), default to 10

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,7 @@
  - Fix a rchk bug
  - Enable CURLOPT_PIPEWAIT by default to prefer multiplex when possible
  - Enable setting max_streams in multi_set(), default to 10
+ - Allow open(curl::curl()) to be interrupted
 
 6.0.1
  - Fix a build issue with libcurl 8.11.0

--- a/src/curl.c
+++ b/src/curl.c
@@ -226,7 +226,7 @@ static Rboolean rcurl_open(Rconnection con) {
     massert(curl_multi_wait(req->manager, NULL, 0, 1000, &numfds));
     if(pending_interrupt()) {
       reset(con); //cleanup before jumping
-      assert_message(CURLE_ABORTED_BY_CALLBACK, "");
+      assert_message(CURLE_ABORTED_BY_CALLBACK, NULL);
     }
     massert(curl_multi_perform(req->manager, &(req->has_more)));
     for(int msg = 1; msg > 0;){

--- a/src/curl.c
+++ b/src/curl.c
@@ -224,6 +224,10 @@ static Rboolean rcurl_open(Rconnection con) {
   while(block_open && req->has_more && !req->has_data) {
     int numfds;
     massert(curl_multi_wait(req->manager, NULL, 0, 1000, &numfds));
+    if(pending_interrupt()) {
+      reset(con); //cleanup before jumping
+      assert_message(CURLE_ABORTED_BY_CALLBACK, "");
+    }
     massert(curl_multi_perform(req->manager, &(req->has_more)));
     for(int msg = 1; msg > 0;){
       CURLMsg *out = curl_multi_info_read(req->manager, &msg);

--- a/src/utils.c
+++ b/src/utils.c
@@ -2,15 +2,20 @@
 #include <stdint.h> /* SIZE_MAX */
 
 #ifdef _WIN32
+extern Rboolean R_Interactive;
 #include <Rembedded.h>
 void send_r_interrupt() {
-  UserBreak = 1;
-  R_CheckUserInterrupt();
+  if(R_Interactive == TRUE){
+    UserBreak = 1;
+    R_CheckUserInterrupt();
+  }
 }
 #else
 #include <Rinterface.h>
 void send_r_interrupt() {
-  Rf_onintr();
+  if(R_Interactive == TRUE){
+    Rf_onintr();
+  }
 }
 #endif
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -2,20 +2,15 @@
 #include <stdint.h> /* SIZE_MAX */
 
 #ifdef _WIN32
-extern Rboolean R_Interactive;
 #include <Rembedded.h>
 void send_r_interrupt() {
-  if(R_Interactive == TRUE){
-    UserBreak = 1;
-    R_CheckUserInterrupt();
-  }
+  UserBreak = 1;
+  R_CheckUserInterrupt();
 }
 #else
 #include <Rinterface.h>
 void send_r_interrupt() {
-  if(R_Interactive == TRUE){
-    Rf_onintr();
-  }
+  Rf_onintr();
 }
 #endif
 


### PR DESCRIPTION
This is a nicer experience in interactive mode, however when running in non-interactive scripts (particularly CI jobs) I think it may still be better to raise an error, such that the log files clearly show that the job was interrupted. 

Update: apparently `R_Interactive` is also a "non-api" call so we don't differentiate between non/interactive mode.

Fixes #363. Fixes #271. Closes #364.