### PR TITLE
MacOS: temporary use static build of libcurl because the apple build …

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,6 +48,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - if: runner.os == 'macos'
+        run: brew uninstall --ignore-dependencies curl || true
+
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ inst/doc
 windows
 configure.log
 src/ada*
+autobrew
+.deps

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,5 @@
 6.2.0
+ - MacOS: temporary use static build of libcurl because the apple build is broken
  - Fix LTO error for R_multi_setopt
  - Fix parsing of #fragment links in curl_parse() (#366)
 

--- a/R/options.R
+++ b/R/options.R
@@ -23,7 +23,7 @@ curl_options <- function(filter = ""){
 }
 
 # Remove this when RHEL-8 is EOL
-option_table_legacy <- if(.Platform$OS.type == "unix" && grepl("^7", libcurlVersion())){
+option_table_legacy <- if(grepl("linux", version$os) && grepl("^7", libcurlVersion())){
   (function(){
     env <- new.env()
     if(file.exists("tools/option_table.txt")){

--- a/cleanup
+++ b/cleanup
@@ -1,3 +1,4 @@
 #!/bin/sh
 rm -f src/Makevars configure.log
 rm -f src/ada*
+rm -Rf .deps autobrew

--- a/configure
+++ b/configure
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Anticonf (tm) script by Jeroen Ooms (2024)
+# Anticonf (tm) script by Jeroen Ooms (2025)
 # This script will query 'pkg-config' for the required cflags and ldflags.
 # If pkg-config is unavailable or does not find the library, try setting
 # INCLUDE_DIR and LIB_DIR manually via e.g:
@@ -15,8 +15,14 @@ PKG_CFLAGS=""
 
 #export PKG_CONFIG_PATH="/opt/homebrew/opt/curl/lib/pkgconfig"
 
+# (Jan 2025) MacOS ships a very buggy libcurl 8.7.1 so we avoid this until apple updates it
+# See: https://github.com/jeroen/curl/issues/376
+if [ `uname` = "Darwin" ]; then
+MINVERSION="--atleast-version=8.8.0"
+fi
+
 # Use pkg-config if available
-pkg-config --version >/dev/null 2>&1
+pkg-config ${PKG_CONFIG_NAME} ${MINVERSION} 2>/dev/null
 if [ $? -eq 0 ]; then
   PKGCONFIG_CFLAGS=`pkg-config --cflags ${PKG_CONFIG_NAME}`
   case "$PKGCONFIG_CFLAGS" in
@@ -34,6 +40,10 @@ elif [ "$PKGCONFIG_CFLAGS" ] || [ "$PKGCONFIG_LIBS" ]; then
   echo "Found pkg-config cflags and libs!"
   PKG_CFLAGS=${PKGCONFIG_CFLAGS}
   PKG_LIBS=${PKGCONFIG_LIBS}
+elif [ `uname` = "Darwin" ]; then
+  # Temporary fix for: https://github.com/jeroen/curl/issues/376
+  curl -sfL "https://autobrew.github.io/scripts/libcurl" > autobrew
+  . ./autobrew
 fi
 
 # Find compiler


### PR DESCRIPTION
…is broken

Fixes #376
Fixes #374
Fixes #360
Fixes #358
