### PR TITLE
Fix for change in behavior of libcurl 8.12

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: curl
 Type: Package
 Title: A Modern and Flexible Web Client for R
-Version: 6.2.0.9000
+Version: 6.2.1
 Authors@R: c(
     person("Jeroen", "Ooms", role = c("aut", "cre"), email = "jeroenooms@gmail.com",
       comment = c(ORCID = "0000-0002-4035-0289")),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+6.2.1
+ - Workaround for change of behavior in libcurl 8.12.0
+
 6.2.0
  - MacOS: we have temporarily switched to a static build of libcurl 8.11.1 until
    apple updates their very buggy libcurl (#376)

--- a/src/multi.c
+++ b/src/multi.c
@@ -188,7 +188,7 @@ SEXP R_multi_run(SEXP pool_ptr, SEXP timeout, SEXP max){
     R_CheckUserInterrupt();
 
     /* check for timeout or max result*/
-    if(result_max > 0 && total_success + total_fail >= result_max)
+    if(total_pending > 0 && result_max > 0 && total_success + total_fail >= result_max)
       break;
     if(time_max == 0 && total_pending != -1)
       break;


### PR DESCRIPTION
Make sure to always call perform one more time, even after all results have been completed. Fixes https://github.com/jeroen/curl/issues/386