### PR TITLE
Add class name to multi error string

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -70,3 +70,16 @@ raise_libcurl_error <- function(errnum, message, errbuf = NULL, source_url = NUL
   )
   stop(e)
 }
+
+call_multi_error_cb <- function(errnum, message, error_cb){
+  if(!length(formals(error_cb))){
+    return(error_cb())
+  } else {
+    error_code <- libcurl_error_codes[errnum]
+    if(is.na(error_code))
+      error_code <- NULL #future proof new error codes
+    class(message) <- c(error_code, "curl_error")
+    error_cb(message)
+  }
+}
+


### PR DESCRIPTION
Fixes #385


```r
# This handle raises an error
handle <- new_handle(url = "https://urldoesnotexist.xyz")
multi_add(handle, fail = function(err){
  print(err)
})

out <- multi_run()

## [1] "Could not resolve host: urldoesnotexist.xyz"
## attr(,"class")
## [1] "curl_error_couldnt_resolve_host" "curl_error"

```