### PR TITLE
fix attribute-warning

### DIFF
--- a/src/download.c
+++ b/src/download.c
@@ -27,7 +27,7 @@ SEXP R_download_curl(SEXP url, SEXP destfile, SEXP quiet, SEXP mode, SEXP ptr, S
 
   /* set options */
   curl_easy_setopt(handle, CURLOPT_URL, Rf_translateCharUTF8(Rf_asChar(url)));
-  curl_easy_setopt(handle, CURLOPT_NOPROGRESS, Rf_asLogical(quiet));
+  curl_easy_setopt(handle, CURLOPT_NOPROGRESS, (long)Rf_asLogical(quiet));
   curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, push_disk);
   curl_easy_setopt(handle, CURLOPT_WRITEDATA, dest);
   curl_easy_setopt(handle, CURLOPT_FAILONERROR, 1L);

--- a/src/handle.c
+++ b/src/handle.c
@@ -272,7 +272,7 @@ SEXP R_handle_setopt(SEXP ptr, SEXP keys, SEXP values){
 
       set_user_option(CURLOPT_XFERINFOFUNCTION, (curl_xferinfo_callback) R_curl_callback_xferinfo);
       set_user_option(CURLOPT_XFERINFODATA, val);
-      set_user_option(CURLOPT_NOPROGRESS, 0);
+      set_user_option(CURLOPT_NOPROGRESS, 0L);
       SET_VECTOR_ELT(prot, 1, val); //protect gc
     } else if (key == CURLOPT_PROGRESSFUNCTION) {
       if (TYPEOF(val) != CLOSXP)
@@ -280,7 +280,7 @@ SEXP R_handle_setopt(SEXP ptr, SEXP keys, SEXP values){
 
       set_user_option(CURLOPT_PROGRESSFUNCTION,(curl_progress_callback) R_curl_callback_progress);
       set_user_option(CURLOPT_PROGRESSDATA, val);
-      set_user_option(CURLOPT_NOPROGRESS, 0);
+      set_user_option(CURLOPT_NOPROGRESS, 0L);
       SET_VECTOR_ELT(prot, 2, val); //protect gc
     } else if (key == CURLOPT_READFUNCTION) {
       if (TYPEOF(val) != CLOSXP)


### PR DESCRIPTION
Just a quick fix for the warnings below

```R
gcc -shared -L/usr/lib64/R/lib -Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,pack-relative-relocs -flto=auto -o curl.so callbacks.o curl.o download.o dryrun.o escape.o fetch.o findport.o form.o getdate.o handle.o ieproxy.o init.o interrupt.o multi.o nslookup.o options.o reflist.o split.o ssl.o typechecking.o urlparser.o utils.o version.o winidn.o writer.o -lcurl -L/usr/lib64/R/lib -lR
handle.c: In function ‘R_handle_setopt’:
handle.c:275:7: warning: call to ‘Wcurl_easy_setopt_err_long’ declared with attribute warning: curl_easy_setopt expects a long argument [-Wattribute-warning]
  275 |       set_user_option(CURLOPT_NOPROGRESS, 0);
      |       ^
handle.c:283:7: warning: call to ‘Wcurl_easy_setopt_err_long’ declared with attribute warning: curl_easy_setopt expects a long argument [-Wattribute-warning]
  283 |       set_user_option(CURLOPT_NOPROGRESS, 0);
      |       ^
download.c: In function ‘R_download_curl’:
download.c:30:3: warning: call to ‘Wcurl_easy_setopt_err_long’ declared with attribute warning: curl_easy_setopt expects a long argument [-Wattribute-warning]
   30 |   curl_easy_setopt(handle, CURLOPT_NOPROGRESS, Rf_asLogical(quiet));
      |   ^
```