### PR TITLE
fix: prevent buffer overflow when read callback over returns

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -51,6 +51,11 @@ size_t R_curl_callback_read(char *buffer, size_t size, size_t nitems, SEXP fun) 
   }
 
   size_t bytes_read = Rf_length(res);
+  if (bytes_read > size * nitems) {
+    UNPROTECT(3);
+    Rf_warning("read callback returned more data than requested");
+    return CURL_READFUNC_ABORT;
+  }
   if (bytes_read) memcpy(buffer, RAW_RO(res), bytes_read);
 
   UNPROTECT(3);


### PR DESCRIPTION
This only happens as far I can tell when the user provides an own callback.