### PR TITLE
fix: prevent parse_date() overflow for dates after 2038

### DIFF
--- a/src/getdate.c
+++ b/src/getdate.c
@@ -6,11 +6,11 @@ SEXP R_curl_getdate(SEXP datestring) {
     Rf_error("Argument 'datestring' must be string.");
 
   int len = Rf_length(datestring);
-  SEXP out = PROTECT(Rf_allocVector(INTSXP, len));
+  SEXP out = PROTECT(Rf_allocVector(REALSXP, len));
 
   for(int i = 0; i < len; i++){
     time_t date = curl_getdate(CHAR(STRING_ELT(datestring, i)), NULL);
-    INTEGER(out)[i] = date < 0 ? NA_INTEGER : (int) date;
+    REAL(out)[i] = date < 0 ? NA_REAL : (double) date;
   }
   UNPROTECT(1);
   return out;


### PR DESCRIPTION
``` r
library(curl)
#> Using libcurl 8.14.1 with LibreSSL/3.3.6

parse_date("Sat, 01 Jan 2040 00:00:00 GMT")
#> [1] "1903-11-25 18:31:44 CET"
parse_date("Fri, 01 Jan 2100 00:00:00 UTC")
#> [1] "1963-11-25 18:31:44 CET"
```

<sup>Created on 2026-06-02 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>