### PR TITLE
fix: label parse_date() result as UTC

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -33,6 +33,7 @@ curl_version <- function(){
 parse_date <- function(datestring){
   out <- .Call(R_curl_getdate, datestring);
   class(out) <- c("POSIXct", "POSIXt")
+  attr(out, "tzone") <- "UTC"
   out
 }
 


### PR DESCRIPTION
I'm pretty sure `curl_getdate()` always returns UTC time zone no matter the input. I would argue that setting it to UTC is more correct, since not setting it is treated as the system time zone in base R and libraries such as lubridate.