### PR TITLE
Revert "fix: label parse_date() result as UTC"

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -33,7 +33,6 @@ curl_version <- function(){
 parse_date <- function(datestring){
   out <- .Call(R_curl_getdate, datestring);
   class(out) <- c("POSIXct", "POSIXt")
-  attr(out, "tzone") <- "UTC"
   out
 }
 


### PR DESCRIPTION
Reverts jeroen/curl#439

Probably wasn't the best decision. There are a couple of other places using no time zone, and httr2 also made the same decision. Sorry about that ...